### PR TITLE
ID-115: Boost warnings only when needed

### DIFF
--- a/client/Makefile
+++ b/client/Makefile
@@ -9,7 +9,7 @@ ifeq ("$(wildcard $(CONFIG_PATH))","")
 $(error Not a valid config: check your CONFIG_PATH variable)
 endif
 ifeq ("$(shell which npx)","")
-$(error 'npx' not found, try installing 'node')
+$(error 'npx' not found, try installing 'node', see README about 'node')
 endif
 
 port = $(shell node -p "require('$(CONFIG_PATH)').client.PORT")

--- a/py_server/Makefile
+++ b/py_server/Makefile
@@ -18,7 +18,7 @@ ifeq ("$(wildcard $(CONFIG_PATH))","")
 $(error "Not a valid config: check your CONFIG_PATH variable")
 endif
 ifeq ("$(shell which node)","")
-$(error 'node' not found, try installing it somehow, I don't know:0)
+$(error 'node' not found, see README about node)
 endif
 
 getField = $(shell node -p "require('$(CONFIG_PATH)').py_server.$1")

--- a/server/Makefile
+++ b/server/Makefile
@@ -36,7 +36,7 @@ ifneq ($V,2)
 .SILENT:
 endif
 .DEFAULT_GOAL = default
-.PHONY: default serve test test.% clean
+.PHONY: default serve test test.% clean checkboost
 
 include $(wildcard $(dirBuild)/*.d)
 
@@ -104,7 +104,7 @@ ifeq ("$(wildcard $(CONFIG_PATH))","")
 $(error $(CONFIG_PATH): Not a valid config: check your CONFIG_PATH variable)
 endif
 ifeq ($(shell which node),)
-$(error 'node' not found, try installing it somehow, I don't know:0)
+$(error 'node' not found, see README about node)
 endif
 
 getField = $(shell node -p "require('$(CONFIG_PATH)').cpp_server.$1")
@@ -112,16 +112,6 @@ port = $(call getField,PORT)
 host = $(call getField,HOST)
 boost = $(call getField,BOOST_ROOT)
 
-# check boost
-ifeq ("$(wildcard $(boost))","")
-$(warning $(boost): Not a valid boost path: check your BOOST_ROOT in the config)
-endif
-ifeq ("$(wildcard $(boost)/lib)","")
-$(warning $(boost): No `lib` folder found: check BOOST_ROOT in the config)
-endif
-ifeq ("$(wildcard $(boost)/include)","")
-$(warning $(boost): No `include` folder found: check BOOST_ROOT in the config)
-endif
 CPPFLAGS += -isystem $(boost)/include
 
 serverFiles = $(wildcard $(dirApi)/*.cpp)
@@ -129,7 +119,7 @@ serverObjects = $(call getObjects,$(serverFiles),$(dirApi))
 
 serve: $(server); $< $(host) $(port)
 
-$(server): $(serverObjects) $(coreArchive) | $(dirBin)
+$(server): $(serverObjects) $(coreArchive) | checkboost $(dirBin)
 	$(LINK.cpp) -L $(boost)/lib $^ -o $@
 
 
@@ -152,6 +142,19 @@ $(dirBin)/test%: $(dirBuild)/%Tests.o $(coreArchive) | $(dirBin)
 
 
 ### COMMON ###
+
+warning = "'\033[0;33mWarning\033[0m'"
+checkboost:
+	if [ -z "$(boost)" -o ! -d "$(boost)" ]; then \
+		echo "$(warning): '$(boost)' is invalid: BOOST_ROOT is empty or not valid, check it in the config.json"; \
+	else \
+		if [ ! -d "$(boost)/lib" ]; then \
+			echo "$(warning): '$(boost)': No 'lib' folder found: check BOOST_ROOT in the config"; \
+		fi; \
+		if [ ! -d "$(boost)/include" ]; then \
+			echo "$(warning): '$(boost)': No 'include' folder found: check BOOST_ROOT in the config"; \
+		fi; \
+	fi
 
 $(dirBuild) $(dirBin): ; mkdir $@
 

--- a/server/api/GraphBuilder.h
+++ b/server/api/GraphBuilder.h
@@ -1,6 +1,7 @@
 #include <set>
 
 #include <crow_all.h>
+#include "Parser.h"
 #include "Layer.h"
 
 class Graph {

--- a/server/api/Parser.h
+++ b/server/api/Parser.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <algorithm>
 #include <map>
 #include <memory>
@@ -11,17 +13,8 @@
 #include "Tensor.h"
 #include "RandomInit.h"
 #include "Optimizer.h"
+#include "Parameters.h"
 
-struct LinearLayerParameters {
-    size_t inFeatures;
-    size_t outFeatures;
-    bool bias;
-};
-
-struct Data2dLayerParameters {
-    size_t width;
-    size_t height;
-};
 
 void CHECK_HAS_FIELD(const crow::json::rvalue& layer, const std::string& field);
 

--- a/server/core/Layer.cpp
+++ b/server/core/Layer.cpp
@@ -1,7 +1,6 @@
 #include <unordered_map>
 #include <functional>
 #include <string>
-#include <vector>
 
 #include "Layer.h"
 

--- a/server/core/Layer.h
+++ b/server/core/Layer.h
@@ -1,14 +1,11 @@
 #pragma once
 
-#include <map>
-#include <unordered_map>
 #include <optional>
-#include <string>
 #include <vector>
 
 #include "RandomInit.h"
 #include "Tensor.h"
-#include "Parser.h"
+#include "Parameters.h"
 
 
 class Layer {

--- a/server/core/Parameters.h
+++ b/server/core/Parameters.h
@@ -1,0 +1,12 @@
+#pragma once
+
+struct LinearLayerParameters {
+    std::size_t inFeatures;
+    std::size_t outFeatures;
+    bool bias;
+};
+
+struct Data2dLayerParameters {
+    std::size_t width;
+    std::size_t height;
+};


### PR DESCRIPTION
По запросу Макса система сборки проверяет на бусы только когда вы именно сервер хотите запустить, на core она буст не проверяет. Также обнаружилась некоторая глиномесия с хедерами и не было проверки что включаем хедер один раз. Добавил проверку и вынес структуру с параметрами для слоев в отдельный хедер `Parameters.h`