### PR TITLE
ID-160: Fix bug (updating parameters in wrong layer)

### DIFF
--- a/client/templates/main.html
+++ b/client/templates/main.html
@@ -379,7 +379,7 @@
       })
 
       const linear_bias_selector = document.getElementById("bias-parameter")
-      linear_bias_selector.addEventListener("change", () =>  {
+      linear_bias_selector.addEventListener("change", () => {
         const parameters = getParametersFromNode(last_selected_node_id)
         console.log("last id: " + last_selected_layer_id)
         const new_value = document.getElementById("bias-parameter").value
@@ -413,7 +413,7 @@
           }
         }
       })
-      linear_inFeatures_input.addEventListener("input", () =>  {
+      linear_inFeatures_input.addEventListener("input", () => {
         last_changed_parameters_layer_id = last_selected_node_id
       })
 
@@ -431,7 +431,7 @@
           }
         }
       })
-      linear_outFeatures_input.addEventListener("input", () =>  {
+      linear_outFeatures_input.addEventListener("input", () => {
         last_changed_parameters_layer_id = last_selected_node_id
       })
 

--- a/client/templates/main.html
+++ b/client/templates/main.html
@@ -406,47 +406,56 @@
 
       const linear_inFeatures_input = document.getElementById("linear-inFeatures-parameter")
       linear_inFeatures_input.addEventListener("change", function () {
-        var parameters = getParametersFromNode(last_selected_node_id)
+        var parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
         var new_value = document.getElementById("linear-inFeatures-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "inFeatures") {
             parameters[i][1] = new_value
-            joinUpdatedLayerParameters(parameters, last_selected_node_id)
+            joinUpdatedLayerParameters(parameters, last_changed_parameters_layer_id)
             break
           }
         }
       })
+      linear_inFeatures_input.addEventListener("input", function () {
+        last_changed_parameters_layer_id = last_selected_node_id
+      })
 
       const linear_outFeatures_input = document.getElementById("linear-outFeatures-parameter")
       linear_outFeatures_input.addEventListener("change", function () {
-        var parameters = getParametersFromNode(last_selected_node_id)
+        var parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
         var new_value = document.getElementById("linear-outFeatures-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "outFeatures") {
             parameters[i][1] = new_value
-            joinUpdatedLayerParameters(parameters, last_selected_node_id)
+            joinUpdatedLayerParameters(parameters, last_changed_parameters_layer_id)
             break
           }
         }
       })
+      linear_outFeatures_input.addEventListener("input", function () {
+        last_changed_parameters_layer_id = last_selected_node_id
+      })
 
       const special_width_input = document.getElementById("special-width-parameter")
       special_width_input.addEventListener("change", function () {
-        var parameters = getParametersFromNode(last_selected_node_id)
+        var parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
         var new_value = document.getElementById("special-width-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "width") {
             parameters[i][1] = new_value
-            joinUpdatedLayerParameters(parameters, last_selected_node_id)
+            joinUpdatedLayerParameters(parameters, last_changed_parameters_layer_id)
             break
           }
         }
+      })
+      special_width_input.addEventListener("input", function () {
+        last_changed_parameters_layer_id = last_selected_node_id
       })
 
       /* DRAG EVENT */
@@ -813,6 +822,7 @@
       console.log(`current address ${py_server_address}`)
 
       let last_selected_layer_id // layer's db id
+      let last_changed_parameters_layer_id
       let train_status = false
       var last_selected_node_id // not db id
 

--- a/client/templates/main.html
+++ b/client/templates/main.html
@@ -385,9 +385,9 @@
 
       const linear_bias_selector = document.getElementById("bias-parameter")
       linear_bias_selector.addEventListener("change", function () {
-        var parameters = getParametersFromNode(last_selected_node_id)
+        let parameters = getParametersFromNode(last_selected_node_id)
         console.log("last id: " + last_selected_layer_id)
-        var new_value = document.getElementById("bias-parameter").value
+        let new_value = document.getElementById("bias-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "bias") {
@@ -405,10 +405,10 @@
       })
 
       const linear_inFeatures_input = document.getElementById("linear-inFeatures-parameter")
-      linear_inFeatures_input.addEventListener("change", function () {
-        var parameters = getParametersFromNode(last_changed_parameters_layer_id)
+      linear_inFeatures_input.addEventListener("change", () => {
+        let parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
-        var new_value = document.getElementById("linear-inFeatures-parameter").value
+        let new_value = document.getElementById("linear-inFeatures-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "inFeatures") {
@@ -423,10 +423,10 @@
       })
 
       const linear_outFeatures_input = document.getElementById("linear-outFeatures-parameter")
-      linear_outFeatures_input.addEventListener("change", function () {
-        var parameters = getParametersFromNode(last_changed_parameters_layer_id)
+      linear_outFeatures_input.addEventListener("change", () => {
+        let parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
-        var new_value = document.getElementById("linear-outFeatures-parameter").value
+        let new_value = document.getElementById("linear-outFeatures-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "outFeatures") {
@@ -441,10 +441,10 @@
       })
 
       const special_width_input = document.getElementById("special-width-parameter")
-      special_width_input.addEventListener("change", function () {
-        var parameters = getParametersFromNode(last_changed_parameters_layer_id)
+      special_width_input.addEventListener("change", () => {
+        let parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
-        var new_value = document.getElementById("special-width-parameter").value
+        let new_value = document.getElementById("special-width-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "width") {
@@ -454,7 +454,7 @@
           }
         }
       })
-      special_width_input.addEventListener("input", function () {
+      special_width_input.addEventListener("input", () => {
         last_changed_parameters_layer_id = last_selected_node_id
       })
 

--- a/client/templates/main.html
+++ b/client/templates/main.html
@@ -379,10 +379,10 @@
       })
 
       const linear_bias_selector = document.getElementById("bias-parameter")
-      linear_bias_selector.addEventListener("change", function () {
-        let parameters = getParametersFromNode(last_selected_node_id)
+      linear_bias_selector.addEventListener("change", () =>  {
+        const parameters = getParametersFromNode(last_selected_node_id)
         console.log("last id: " + last_selected_layer_id)
-        let new_value = document.getElementById("bias-parameter").value
+        const new_value = document.getElementById("bias-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "bias") {
@@ -401,9 +401,9 @@
 
       const linear_inFeatures_input = document.getElementById("linear-inFeatures-parameter")
       linear_inFeatures_input.addEventListener("change", () => {
-        let parameters = getParametersFromNode(last_changed_parameters_layer_id)
+        const parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
-        let new_value = document.getElementById("linear-inFeatures-parameter").value
+        const new_value = document.getElementById("linear-inFeatures-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "inFeatures") {
@@ -413,15 +413,15 @@
           }
         }
       })
-      linear_inFeatures_input.addEventListener("input", function () {
+      linear_inFeatures_input.addEventListener("input", () =>  {
         last_changed_parameters_layer_id = last_selected_node_id
       })
 
       const linear_outFeatures_input = document.getElementById("linear-outFeatures-parameter")
       linear_outFeatures_input.addEventListener("change", () => {
-        let parameters = getParametersFromNode(last_changed_parameters_layer_id)
+        const parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
-        let new_value = document.getElementById("linear-outFeatures-parameter").value
+        const new_value = document.getElementById("linear-outFeatures-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "outFeatures") {
@@ -431,15 +431,15 @@
           }
         }
       })
-      linear_outFeatures_input.addEventListener("input", function () {
+      linear_outFeatures_input.addEventListener("input", () =>  {
         last_changed_parameters_layer_id = last_selected_node_id
       })
 
       const special_width_input = document.getElementById("special-width-parameter")
       special_width_input.addEventListener("change", () => {
-        let parameters = getParametersFromNode(last_changed_parameters_layer_id)
+        const parameters = getParametersFromNode(last_changed_parameters_layer_id)
         console.log("last id: " + last_selected_layer_id)
-        let new_value = document.getElementById("special-width-parameter").value
+        const new_value = document.getElementById("special-width-parameter").value
 
         for (i in parameters) {
           if (parameters[i][0] == "width") {


### PR DESCRIPTION
[ID-160](https://ru.yougile.com/team/b400e1850fe9/#GRA-160)
`Баг:` открываем параметры слоя №1, меняем ему какой-нибудь параметр (баг проявлялся с полями ввода, например, inFeatures). Просто записали новое значение параметра, дальше просто кликаем на слой №2 => параметры обновляются у слоя №2, но должны у слоя №1. 

Починил я этот баг достаточно дешево, просто ввел новую переменную. Но это очередная переменная, назначение которой может быть плохо понятно человеку, который полезет разбираться в нашем фронтенде. Поэтому я думаю **завести документацию на фронт** (мб в Notion) - просто будет описана семантика основных методов, описание переменных. 

Сам баг фикс: теперь когда пользователь меняет какие-то данные в параметрах, то программа запоминает id этого слоя. В предыдущей реализации был только `event listener` на событие `change`, то есть прям изменение значения в поле для ввода, ну там надо было Enter нажать, чтоб запрос к бд отработал. А сейчас вообще всегда должно работать, в любом случае правильно запомнится id и отправится запрос к бд.