### PR TITLE
Server exceptions handler

### DIFF
--- a/server/api/server.cpp
+++ b/server/api/server.cpp
@@ -190,6 +190,8 @@ int main(int argc, char *argv[]) {
         } catch (const std::runtime_error &err) {
             std::cout << err.what() << std::endl;
             return response(status::BAD_REQUEST, "Invalid body");
+        } catch (...) {
+            return response(status::INTERNAL_SERVER_ERROR, "Predict failed");
         }
         json::wvalue response = (int)(answer[1] > answer[0]);
         return crow::response(status::OK, response);
@@ -205,8 +207,12 @@ int main(int argc, char *argv[]) {
             delete sessions[model_id];
         }
         Graph* g = nullptr;
-
-        train(body, &g, model_id, user_id, file_types[model_id]);
+        try {
+            train(body, &g, model_id, user_id, file_types[model_id]);
+        }
+        catch (...) {
+            return response(status::INTERNAL_SERVER_ERROR, "Train failed");
+        }
         sessions[model_id] = g;
         return response(status::OK, "done");
     });
@@ -248,6 +254,9 @@ int main(int argc, char *argv[]) {
         }
 
         std::ofstream out_file(path, ios::binary);
+        if (!out_file) {
+            return response(status::INTERNAL_SERVER_ERROR, "Error in loading zip");
+        }
         out_file << req.body;
         out_file.close();
 


### PR DESCRIPTION
Добавил несколько try_catch. Теперь в них обёрнуты вызов каждой функции (например, train) и вся работа с файлами в main. Кажется, нужно добавить их обработку на фронтенде. И это не спасает от segfault. Как я понял, если он возник, то его не остановить. Но я не могу его проверить и подебажить, т.к. если он возникает, то в ML-ной части